### PR TITLE
Fixed invalid Carbon service's parameters and removed template warnings

### DIFF
--- a/manifests/carbon/aggregator/service.pp
+++ b/manifests/carbon/aggregator/service.pp
@@ -100,10 +100,10 @@ class graphite::carbon::aggregator::service {
   service { 'carbon-aggregator':
     ensure     => $service_ensure,
     enable     => $service_enable,
-    name       => $graphite::params::service_name,
-    hasstatus  => $graphite::params::service_hasstatus,
-    hasrestart => $graphite::params::service_hasrestart,
-    pattern    => $graphite::params::service_pattern,
+    name       => $graphite::params::service_aggregator_name,
+    hasstatus  => $graphite::params::service_aggregator_hasstatus,
+    hasrestart => $graphite::params::service_aggregator_hasrestart,
+    pattern    => $graphite::params::service_aggregator_pattern,
   }
 
 }

--- a/manifests/carbon/cache/service.pp
+++ b/manifests/carbon/cache/service.pp
@@ -100,10 +100,10 @@ class graphite::carbon::cache::service {
   service { 'carbon-cache':
     ensure     => $service_ensure,
     enable     => $service_enable,
-    name       => $graphite::params::service_name,
-    hasstatus  => $graphite::params::service_hasstatus,
-    hasrestart => $graphite::params::service_hasrestart,
-    pattern    => $graphite::params::service_pattern,
+    name       => $graphite::params::service_cache_name,
+    hasstatus  => $graphite::params::service_cache_hasstatus,
+    hasrestart => $graphite::params::service_cache_hasrestart,
+    pattern    => $graphite::params::service_cache_pattern,
   }
 
 }

--- a/manifests/carbon/relay/service.pp
+++ b/manifests/carbon/relay/service.pp
@@ -100,10 +100,10 @@ class graphite::carbon::relay::service {
   service { 'carbon-relay':
     ensure     => $service_ensure,
     enable     => $service_enable,
-    name       => $graphite::params::service_name,
-    hasstatus  => $graphite::params::service_hasstatus,
-    hasrestart => $graphite::params::service_hasrestart,
-    pattern    => $graphite::params::service_pattern,
+    name       => $graphite::params::service_relay_name,
+    hasstatus  => $graphite::params::service_relay_hasstatus,
+    hasrestart => $graphite::params::service_relay_hasrestart,
+    pattern    => $graphite::params::service_relay_pattern,
   }
 
 }

--- a/templates/etc/carbon/storage-schemas-item.erb
+++ b/templates/etc/carbon/storage-schemas-item.erb
@@ -1,4 +1,4 @@
-[<%= name %>]
-pattern = <%= pattern %>
-retentions = <%= retentions %>
+[<%= @name %>]
+pattern = <%= @pattern %>
+retentions = <%= @retentions %>
 


### PR DESCRIPTION
I didn't find variable eg. "$graphite::params::service_name". Got this working by fixing all variables. For example in Carbon-cache service:
$graphite::params::service_name => $graphite::params::service_cache_name

Warnings what I got from template were:
Warning: Variable access via 'name' is deprecated. Use '@name' instead. template[/opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb]:1
   (at /opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb:1:in `result')
Warning: Variable access via 'pattern' is deprecated. Use '@pattern' instead. template[/opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb]:2
   (at /opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb:2:in`result')
Warning: Variable access via 'retentions' is deprecated. Use '@retentions' instead. template[/opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb]:3
   (at /opt/provisioning/provision/modules/graphite/templates/etc/carbon/storage-schemas-item.erb:3:in `result')
