### PR TITLE
Updated RedHat package names to what is available in EPEL.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -46,8 +46,8 @@ class graphite::params {
   case $::operatingsystem {
     'CentOS', 'Fedora', 'Scientific': {
       # main application
-      $package_carbon  = [ 'carbon' ]
-      $package_whisper = [ 'whisper' ]
+      $package_carbon  = [ 'python-carbon' ]
+      $package_whisper = [ 'python-whisper' ]
       $package_web     = [ 'graphite-web']
     }
     'Debian', 'Ubuntu': {


### PR DESCRIPTION
Now that there are packages in EPEL for whisper, carbon and graphite-web, I thought it would be nice to use those.

I left the variables inside the case statement because I thought it was easier to read this way, even though two out of three package names are now identical between RedHat and Debian.  An alternative would be to make these class  parameters - I don't know where other people get their RPMs from.
